### PR TITLE
Require java recipe for build agents

### DIFF
--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -27,7 +27,7 @@ platforms:
         - ["private_network", {ip: '10.10.10.13'}]
   - name: windows-2016
     driver:
-      box_url: '<%= ENV['KITCHEN_WINDOWS_BOX_URL'] %>'
+      box_url: '<%= ENV["KITCHEN_WINDOWS_BOX_URL"] %>'
       box_check_update: false
       gui: false
       customize:
@@ -40,12 +40,18 @@ suites:
     run_list:
       - recipe[teamcity::default]
     attributes:
+<% if ENV['KITCHEN_TEAMCITY_WINDOWS_JAVA_URL'] %>
+      java:
+        windows:
+          url: '<%= ENV["KITCHEN_TEAMCITY_WINDOWS_JAVA_URL"] %>'
+          checksum: '<%= ENV["KITCHEN_TEAMCITY_WINDOWS_JAVA_CHECKSUM"] %>'
+<% end %>
       teamcity:
         agent:
           windows_service:
             startuptype: 'Manual'
         server:
-          url: '<%= ENV['KITCHEN_TEAMCITY_SERVER'] || '10.10.10.10:8111' %>'
+          url: '<%= ENV["KITCHEN_TEAMCITY_SERVER"] || "10.10.10.10:8111" %>'
   - name: server
     driver:
       customize:

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -47,5 +47,6 @@ default['teamcity']['agent']['windows_service']['startuptype'] = 'Automatic'
 
 # NOTE: Brew does not tag the latest java version with an ID, therefore we must 'nil' it to get the latest.
 default['java']['jdk_version'] = platform_family?('mac_os_x') ? '' : '8'
+default['java']['windows']['url'] = nil
 default['java']['windows']['package_name'] = 'Java SE Development Kit 8 Update 152 (64-bit)'
-default['java']['windows']['checksum'] = 'f9aafc51ae722f50463e7c2d875e8310f8d5145803cd1ed8d9044b358a56f36a'
+default['java']['windows']['checksum'] = nil

--- a/metadata.rb
+++ b/metadata.rb
@@ -4,7 +4,7 @@ maintainer_email 'antek.baranski@gmail.com'
 license          'Apache License, Version 2.0'
 description      'Installs TeamCity server and agent'
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
-version          '3.1.1'
+version          '4.0.0'
 
 recipe 'teamcity::default', 'Installs TeamCity Agent on target OS'
 recipe 'teamcity::server', 'Installs TeamCity Server on CentOS or Ubuntu'

--- a/metadata.rb
+++ b/metadata.rb
@@ -4,7 +4,7 @@ maintainer_email 'antek.baranski@gmail.com'
 license          'Apache License, Version 2.0'
 description      'Installs TeamCity server and agent'
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
-version          '3.1.0'
+version          '3.1.1'
 
 recipe 'teamcity::default', 'Installs TeamCity Agent on target OS'
 recipe 'teamcity::server', 'Installs TeamCity Server on CentOS or Ubuntu'
@@ -15,7 +15,7 @@ supports 'centos'
 
 depends 'ark', '~> 3.0'
 depends 'homebrew', '~> 4.2'
-depends 'java', '~> 1.50'
+depends 'java', '~> 2.0.1'
 depends 'runit', '~> 4.0'
 depends 'seven_zip'
 depends 'systemd'

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -50,6 +50,12 @@ if platform_family?('windows')
   include_recipe 'seven_zip::default'
 end
 
+if platform_family?('windows')
+  include_recipe 'java::windows'
+else
+  include_recipe 'java'
+end
+
 ark 'teamcity-agent' do
   url source
   path node['teamcity']['agent']['install_dir']

--- a/recipes/mac_os_x.rb
+++ b/recipes/mac_os_x.rb
@@ -29,8 +29,6 @@ include_recipe 'homebrew'
 homebrew_tap 'xfreebird/utils'
 package 'kcpassword'
 
-include_recipe 'java'
-
 home_dir = ::File.join(node['teamcity']['agent']['home'], node['teamcity']['agent']['user'])
 root_dir = ::File.join(node['teamcity']['agent']['install_dir'], 'teamcity-agent')
 

--- a/spec/unit/default_spec.rb
+++ b/spec/unit/default_spec.rb
@@ -1,10 +1,35 @@
 require_relative '../spec_helper'
 
 describe 'teamcity::default' do
+  {
+    'ubuntu' => '16.04',
+    'centos' => '7.2',
+  }.each do |p, v|
+    describe p do
+      let(:platform) { p }
+      let(:version) { v }
+      let(:runner) { get_runner(platform, version) }
+
+      cached(:chef_run) do
+        runner.converge(described_recipe)
+      end
+
+      describe 'java' do
+        it 'includes the java recipe' do
+          expect(chef_run).to include_recipe('java')
+        end
+      end
+    end
+  end
+
   describe 'windows' do
     let(:platform) { 'windows' }
     let(:version) { '2016' }
-    let(:runner) { get_runner(platform, version) }
+    let(:runner) do
+      r = get_runner(platform, version)
+      r.node.normal['java']['windows']['url'] = 'http://foo.bar.local'
+      r
+    end
 
     cached(:chef_run) do
       runner.converge(described_recipe)
@@ -16,6 +41,12 @@ describe 'teamcity::default' do
         # doesn't work here
         expect(chef_run.node['seven_zip']['syspath']).to be_truthy
         expect(chef_run).to include_recipe('seven_zip::default')
+      end
+    end
+
+    describe 'java' do
+      it 'includes the java::windows recipe' do
+        expect(chef_run).to include_recipe('java::windows')
       end
     end
 


### PR DESCRIPTION
This is a major version bump because the windows recipe now requires defining some attributes.