### PR TITLE
Fix the `dsc_resource :service` failures

### DIFF
--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -5,7 +5,7 @@ driver:
 
 provisioner:
   name: chef_zero
-  require_chef_omnibus: 13
+  require_chef_omnibus: 13.10.4
   always_update_cookbooks: true
 
 platforms:
@@ -27,14 +27,12 @@ platforms:
         - ["private_network", {ip: '10.10.10.13'}]
   - name: windows-2016
     driver:
-      box_url: '<%= ENV["KITCHEN_WINDOWS_BOX_URL"] %>'
-      box_check_update: false
-      gui: false
+      box_url: 'http://webdav.roblox.local/boxes/windows-2016.json'
       customize:
         cpus: 2
         memory: 4096
       network:
-        - ["private_network", {ip: '10.10.10.14'}]
+        - ["private_network", {ip: '192.168.42.15'}]
 suites:
   - name: default
     run_list:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Change Log
 
-## Unreleased
+## 4.2.2
+* Added a workaround for DSC bug when it doesn't behave in idempotent way with an existing Windows service
 * Fixed README.md (attribute listing and use `doc/`)
 
 ## 4.2.1

--- a/README.md
+++ b/README.md
@@ -171,6 +171,14 @@ Installs TeamCity server and agent
     </tr>
     <tr>
       <td>
+        <code>['ignore_dsc_errors']</code>
+      </td>
+      <td>
+        <strong>Default:</strong> <code>true</code>
+      </td>
+    </tr>
+    <tr>
+      <td>
         <code>node['java']['jdk_version']</code>
       </td>
       <td>

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -43,6 +43,7 @@ default['teamcity']['agent']['home'] = case node['platform_family']
                                        end
 
 default['teamcity']['agent']['windows_service']['startuptype'] = 'Automatic'
+default['teamcity']['ignore_dsc_errors'] = true
 
 # NOTE: Brew does not tag the latest java version with an ID, therefore we must 'nil' it to get the latest.
 default['java']['jdk_version'] = platform_family?('mac_os_x') ? '' : '8'

--- a/metadata.rb
+++ b/metadata.rb
@@ -4,7 +4,7 @@ maintainer_email 'info@roblox.com'
 license          'Apache-2.0'
 description      'Installs TeamCity server and agent'
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
-version          '4.2.1'
+version          '4.2.2'
 
 source_url 'https://github.com/Roblox/chef-teamcity'
 issues_url 'https://github.com/Roblox/chef-teamcity/issues'

--- a/recipes/windows.rb
+++ b/recipes/windows.rb
@@ -37,6 +37,7 @@ dsc_resource 'Setup TeamCity BuildAgent Service' do
   property :description, 'TeamCity Build Agent Service'
   property :displayname, 'TeamCity Build Agent'
   property :path, "#{node['teamcity']['agent']['work_dir']}\\launcher\\bin\\TeamCityAgentService-windows-x86-32.exe -s #{node['teamcity']['agent']['work_dir']}\\launcher\\conf\\wrapper.conf"
+  ignore_failure node['teamcity']['ignore_dsc_errors']
 end
 
 # We declare this here such that downstream dependencies can restart the service to pick up ENV variables.


### PR DESCRIPTION
* Added a workaround for DSC bug when it doesn't behave in idempotent way with an existing Windows service
* Fixed README.md (attribute listing and use `doc/`), updated README with `rake doc`
* Add the existing webdav Windows-2016 box to .kitchen.yml